### PR TITLE
Add consumer proguard rules.

### DIFF
--- a/mozillaspeechlibrary/build.gradle
+++ b/mozillaspeechlibrary/build.gradle
@@ -13,6 +13,7 @@ android {
         versionCode versionMajor * 10000 + versionMinor * 100 + versionPatch
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'proguard-consumer-rules.pro'
 
         ndk {
             abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'

--- a/mozillaspeechlibrary/proguard-consumer-rules.pro
+++ b/mozillaspeechlibrary/proguard-consumer-rules.pro
@@ -1,0 +1,5 @@
+# Let the consumer know, which classes of the library are to be kept.
+
+-keep class cz.msebera.android.httpclient.** {*;}
+-keep class com.loopj.android.http.** {*;}
+-keep class com.github.axet.opusjni.Opus {*;}


### PR DESCRIPTION
I'm working on enabling R8 minification for Firefox Reality and found some problems with the androidspeech library (a crash if Opus class attributes are not kept or connection failures if httpclient dependendies are not kept).

This PR adds proguard rules that will only be applied on the consumer of the library