### PR TITLE
Call cancel on the network thread too when calling cancel on the service

### DIFF
--- a/mozillaspeechlibrary/src/main/java/com/mozilla/speechlibrary/MozillaSpeechService.java
+++ b/mozillaspeechlibrary/src/main/java/com/mozilla/speechlibrary/MozillaSpeechService.java
@@ -89,7 +89,9 @@ public class MozillaSpeechService {
     }
 
     public void cancel() {
-        // this.mNetworkSpeechRecognition.cancel();
+        if (this.mNetworkSpeechRecognition != null) {
+            this.mNetworkSpeechRecognition.cancel();
+        }
         if (this.mLocalSpeechRecognition != null) {
             this.mLocalSpeechRecognition.cancel();
         }


### PR DESCRIPTION
Related to https://github.com/MozillaReality/FirefoxReality/issues/2723. When calling cancel on the service only the local thread is cancelled. Make sure we call cancel on both.