### PR TITLE
Fix recording issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 
-VERSION_NAME=2.0.1
-VERSION_CODE=20000
+VERSION_NAME=2.0.2
+VERSION_CODE=20002
 GROUP=com.github.mozilla
 
 POM_DESCRIPTION=This is an Android library containing an API to Mozilla's speech recognition services

--- a/mozillaspeechlibrary/build.gradle
+++ b/mozillaspeechlibrary/build.gradle
@@ -3,7 +3,7 @@ apply from: 'maven-push.gradle'
 
 def versionMajor = 2
 def versionMinor = 0
-def versionPatch = 1
+def versionPatch = 2
 
 android {
     compileSdkVersion 29

--- a/mozillaspeechlibrary/src/main/java/com/mozilla/speechlibrary/recognition/LocalSpeechRecognition.java
+++ b/mozillaspeechlibrary/src/main/java/com/mozilla/speechlibrary/recognition/LocalSpeechRecognition.java
@@ -18,6 +18,8 @@ public class LocalSpeechRecognition extends SpeechRecognition {
     public void start(@NonNull SpeechServiceSettings settings,
                       @NonNull SpeechResultCallback callback) {
         mStt = new STTLocalClient(mContext, settings, this);
+        Thread sttThread = new Thread((STTLocalClient)mStt, "STT Thread");
+        sttThread.start();
         super.start(settings, callback);
     }
 }

--- a/mozillaspeechlibrary/src/main/java/com/mozilla/speechlibrary/recognition/SpeechRecognition.java
+++ b/mozillaspeechlibrary/src/main/java/com/mozilla/speechlibrary/recognition/SpeechRecognition.java
@@ -79,11 +79,11 @@ public abstract class SpeechRecognition implements STTClientCallback {
             while (mIsRunning && !done) {
                 int nshorts = 0;
 
-                short[] mBuftemp = new short[FRAME_SIZE * CHANNELS * 2];
-                nshorts = mRecorder.read(mBuftemp, 0, mBuftemp.length);
+                short[] mBufTemp = new short[FRAME_SIZE * CHANNELS * 2];
+                nshorts = mRecorder.read(mBufTemp, 0, mBufTemp.length);
 
-                vad = mVad.feed(mBuftemp, nshorts);
-                double[] fft =  Sound.fft(mBuftemp, 0, nshorts);
+                vad = mVad.feed(mBufTemp, nshorts);
+                double[] fft =  Sound.fft(mBufTemp, 0, nshorts);
                 double fftsum = Arrays.stream(fft).sum()/fft.length;
 
                 mCallback.onMicActivity(fftsum);
@@ -100,13 +100,13 @@ public abstract class SpeechRecognition implements STTClientCallback {
                     samplesVoice  += dtdepois - dtantesmili;
                     if (samplesVoice > MIN_VOICE) touchedVoice = true;
 
-                    for (int i = 0; i < mBuftemp.length; ++i) {
-                        mBuftemp[i] *= 5.0;
+                    for (int i = 0; i < mBufTemp.length; ++i) {
+                        mBufTemp[i] *= 5.0;
                     }
                 }
                 dtantesmili = dtdepois;
 
-                mStt.encode(mBuftemp, 0, nshorts);
+                mStt.encode(mBufTemp, 0, nshorts);
 
                 if (touchedVoice && touchedSilence) {
                     done = true;

--- a/mozillaspeechutils/build.gradle
+++ b/mozillaspeechutils/build.gradle
@@ -3,7 +3,7 @@ apply from: 'maven-push.gradle'
 
 def versionMajor = 2
 def versionMinor = 0
-def versionPatch = 1
+def versionPatch = 2
 
 android {
     compileSdkVersion 29


### PR DESCRIPTION
Related to: https://discourse.mozilla.org/t/android-demo-app-poor-inference-results/61348

`nshorts = mRecorder.read(mBuftemp, 0, mBuftemp.length);`
and
`mStt.encode(mBuftemp, 0, nshorts);` 
were beingcalled in the same thread in start method which caused missed voice data.

This PR fixes that running the local STT client in it's own thread.