### PR TITLE
Fix ModelUtils returning false negative

### DIFF
--- a/mozillaspeechlibrary/src/main/java/com/mozilla/speechlibrary/utils/ModelUtils.java
+++ b/mozillaspeechlibrary/src/main/java/com/mozilla/speechlibrary/utils/ModelUtils.java
@@ -150,7 +150,7 @@ public class ModelUtils {
             return false;
         }
         return (new File(getTFLiteFolder(modelPath)).exists()
-                && new File(getLMFolder(modelPath)).exists()
+                && ((new File(modelPath + "/.noUseDecoder")).exists() || new File(getLMFolder(modelPath)).exists())
                 && new File(getTRIEFolder(modelPath)).exists()
                 && new File(getInfoJsonFolder(modelPath)).exists());
     }


### PR DESCRIPTION
Problem:
- Even if a `.noUseDecoder`  file is present, a `scorer` is still required. In implementations that do not supply a scorer file this will cause a critical failure.

Fix:
- If a `.noUseDecoder` or `scorer` file is present then `ModelUtils.isReady` will return `true`.